### PR TITLE
chore: give image build job write permissions

### DIFF
--- a/.github/workflows/athenapdf-service-image.yaml
+++ b/.github/workflows/athenapdf-service-image.yaml
@@ -22,7 +22,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/database-tools-image.yaml
+++ b/.github/workflows/database-tools-image.yaml
@@ -7,7 +7,7 @@ on:
       - 'build-image'
     paths:
       - 'database-tools/**'
-      - '.github/workflows/database-tools.yaml'
+      - '.github/workflows/database-tools-image.yaml'
     tags:
       - 'database-tools-v*.*.*'
   pull_request:
@@ -15,7 +15,7 @@ on:
       - 'main'
     paths:
       - 'database-tools/**'
-      - '.github/workflows/database-tools.yaml'
+      - '.github/workflows/database-tools-image.yaml'
 
 jobs:
   docker:

--- a/.github/workflows/database-tools-image.yaml
+++ b/.github/workflows/database-tools-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-host-image.yaml
+++ b/.github/workflows/docker-host-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/drush-alias-image.yaml
+++ b/.github/workflows/drush-alias-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/insights-scanner-image.yaml
+++ b/.github/workflows/insights-scanner-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/logs-concentrator-image.yaml
+++ b/.github/workflows/logs-concentrator-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest

--- a/.github/workflows/logs-dispatcher-image.yaml
+++ b/.github/workflows/logs-dispatcher-image.yaml
@@ -21,7 +21,7 @@ jobs:
   docker:
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
This enables creating a release from the action.